### PR TITLE
Adds location clause for Bib.isResearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+ - '6.11'

--- a/README.md
+++ b/README.md
@@ -66,3 +66,21 @@ This currently satisfies the API needs of the DiscoveryStoreUpdater and Discover
  * `db.upsertStatements(type = 'resource', statements = [])`
  * `db.deleteStaleStatements(type = 'resource', statements = [], subtype = 'bib')`
 
+
+## Testing
+
+```
+npm test
+```
+
+A script is provided for adding/updating test fixtures.
+
+This will update all fixtures against configured db:
+```
+node scripts/update-test-fixtures --profile [profile] --envfile [creds file]
+```
+
+Use `--id` to update a single bib. For example, this updates fixture for 'b10781594' using qa creds
+```
+node scripts/update-test-fixtures --id b10781594 --profile nypl-sandbox --envfile config/qa.env
+```

--- a/lib/models/base.js
+++ b/lib/models/base.js
@@ -61,6 +61,14 @@ class Base {
   label () {
     return this.literal('skos:prefLabel')
   }
+
+  /**
+   * Partner bibs & items are those records whose id is prefixed with a partner prefix.
+   * At writing, those prefixes are p for PUL/Princeton and c for CUL/Columbia.
+   */
+  isPartner () {
+    return /^[pc]/.test(this.uri)
+  }
 }
 
 /**

--- a/lib/models/bib.js
+++ b/lib/models/bib.js
@@ -4,6 +4,7 @@ const Base = require('./base')
 const Item = require('./item')
 const db = require('../db')
 const utils = require('../utils')
+const sierraLocationMapping = require('@nypl/nypl-core-objects')('by-sierra-location')
 
 class Bib extends Base {
   // Helper to check a bib's suppressed flag:
@@ -17,13 +18,31 @@ class Bib extends Base {
     //  * it's PUL/CUL OR
     //  * it has 0 items OR
     //  * at least one research item
-    return /^[pc]/.test(this.uri) ||
-      this.items().length === 0 ||
-      this.items().filter((item) => item.isResearch()).length > 0
+    //  * its items are all electronic and its nypl:catalogBibLocation[s] include
+    //    locations with collectionType "Research"
+
+    const itemsCount = this.items().length
+    const researchItemsCount = this.items().filter((item) => item.isResearch()).length
+    const nonElectronicItemsCount = this.items().filter((item) => !item.isElectronic()).length
+
+    return this.isPartner() ||
+      itemsCount === 0 ||
+      researchItemsCount > 0 ||
+      (nonElectronicItemsCount === 0 && this.researchLocations().length > 0)
   }
 
   items () {
     return this._items || []
+  }
+
+  /**
+   * Return array of bib locations mapped to nypl-core locations, which have
+   * collectionType 'Research'
+   */
+  researchLocations () {
+    return (this.objectIds('nypl:catalogBibLocation') || [])
+      .map((locationId) => sierraLocationMapping[utils.stripNamespace(locationId)])
+      .filter((location) => location && location.collectionTypes.indexOf('Research') >= 0)
   }
 }
 

--- a/lib/models/item.js
+++ b/lib/models/item.js
@@ -14,8 +14,7 @@ class Item extends Base {
    * item is indexed. An item will be indexed if it is not `suppressed`,
    * which is established upstream in the `pcdm-store-updater`. The check
    * performed here exists solely to determine whether the parent Bib is
-   * 'Research', which will be true if it has at least one Item that is
-   * considered 'Research'
+   * 'Research' (see ./bib.js to see how that determination is made)
    */
   isResearch () {
     // Check catalogItemTypes json-ld vocab to see if itype's collectionTypes includes 'Research':
@@ -27,6 +26,15 @@ class Item extends Base {
       catalogItemTypeMapping[itype].collectionType.indexOf('Research') >= 0
 
     return /^[pc]/.test(this.uri) || itypeIsResearch
+  }
+
+  /**
+   * Returns true if item is an electronic resource
+   *
+   * The presence of bf:electronicLocator indicates it's an e-resource.
+   */
+  isElectronic () {
+    return (this.literal('bf:electronicLocator') || []).length > 0
   }
 }
 

--- a/lib/models/item.js
+++ b/lib/models/item.js
@@ -14,7 +14,7 @@ class Item extends Base {
    * item is indexed. An item will be indexed if it is not `suppressed`,
    * which is established upstream in the `pcdm-store-updater`. The check
    * performed here exists solely to determine whether the parent Bib is
-   * 'Research' (see ./bib.js to see how that determination is made)
+   * 'Research' (see ./bib.js for how that determination is made)
    */
   isResearch () {
     // Check catalogItemTypes json-ld vocab to see if itype's collectionTypes includes 'Research':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,3 +10,7 @@ exports.groupBy = (a, prop) => {
 
   return Object.keys(grouped).map((v) => grouped[v])
 }
+
+exports.stripNamespace = (val) => {
+  return val.split(':').pop()
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/NYPL-discovery/discovery-store-models#readme",
   "dependencies": {
-    "@nypl/nypl-core-objects": "^1.3.0",
+    "@nypl/nypl-core-objects": "^1.3.1",
     "pg-promise": "^7.4.0",
     "winston": "^2.4.0"
   },

--- a/scripts/update-test-fixtures.js
+++ b/scripts/update-test-fixtures.js
@@ -4,12 +4,13 @@
  *  Useage:
  *
  *  This will update all fixtures against configured db:
- *    node jobs/update-test-fixtures
+ *    node scripts/update-test-fixtures --profile [profile] --envfile [creds file]
  *
  *  This will update a single fixture by [bib] id:
+ *    node scripts/update-test-fixtures --id [id] --profile [profile] --envfile [creds file]
  *
  *  For example, this updates fixture for 'b10781594' using qa creds
- *    node jobs/update-test-fixtures --id b10781594 --profile nypl-sandbox --envfile config/qa.env
+ *    node scripts/update-test-fixtures --id b10781594 --profile nypl-sandbox --envfile config/qa.env
  */
 
 const path = require('path')

--- a/test/bib-test.js
+++ b/test/bib-test.js
@@ -44,4 +44,39 @@ describe('Bib model', function () {
       expect(bib.blankNode('skos:note').objectId('rdfs:type')).to.equal('bf:Note')
     })
   })
+
+  it('should identify Research locations', function () {
+    return Bib.byId('b16369525').then((bib) => {
+      expect(bib.researchLocations()).to.be.a('array')
+      expect(bib.researchLocations()).to.have.lengthOf(1)
+      expect(bib.researchLocations()[0]).to.be.a('object')
+      expect(bib.researchLocations()[0].collectionTypes).to.be.a('array')
+      expect(bib.researchLocations()[0].collectionTypes).to.have.lengthOf(2)
+      expect(bib.researchLocations()[0].collectionTypes).to.have.members(['Research', 'Branch'])
+    })
+  })
+
+  describe('Bib.isResearch', function () {
+    it('should identify b16369525 as research because it has 1 electronic item and a Research location', function () {
+      return Bib.byId('b16369525').then((bib) => {
+        expect(bib.isResearch()).to.equal(true)
+      })
+    })
+  })
+
+  describe('Bib.isPartner', function () {
+    it('should identify non-partner bib', function () {
+      return Bib.byId('b18064236').then((bib) => {
+        expect(bib.isPartner()).to.be.a('boolean')
+        expect(bib.isPartner()).to.equal(false)
+      })
+    })
+
+    it('should identify partner bib', function () {
+      return Bib.byId('cb6240214').then((bib) => {
+        expect(bib.isPartner()).to.be.a('boolean')
+        expect(bib.isPartner()).to.equal(true)
+      })
+    })
+  })
 })

--- a/test/data/b16369525.json
+++ b/test/data/b16369525.json
@@ -1,0 +1,502 @@
+{
+  "subject_id": "b16369525",
+  "bib_statements": [
+    {
+      "bn": null,
+      "id": "carriertypes:cr",
+      "la": "online resource",
+      "li": null,
+      "pr": "bf:carrier"
+    },
+    {
+      "bn": null,
+      "id": "urn:biblevel:m",
+      "la": "monograph/item",
+      "li": null,
+      "pr": "bf:issuance"
+    },
+    {
+      "bn": null,
+      "id": "mediatypes:c",
+      "la": "computer",
+      "li": null,
+      "pr": "bf:media"
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "General Note",
+          "pr": "bf:noteType"
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Title from title screen (viewed on May 8, 2006).",
+          "pr": "rdfs:label"
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type"
+        }
+      ],
+      "id": "b16369525#1.0000",
+      "la": null,
+      "li": null,
+      "pr": "bf:note"
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "General Note",
+          "pr": "bf:noteType"
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "\"February 2005.\"",
+          "pr": "rdfs:label"
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type"
+        }
+      ],
+      "id": "b16369525#1.0001",
+      "la": null,
+      "li": null,
+      "pr": "bf:note"
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "General Note",
+          "pr": "bf:noteType"
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "2005-08-21.",
+          "pr": "rdfs:label"
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type"
+        }
+      ],
+      "id": "b16369525#1.0002",
+      "la": null,
+      "li": null,
+      "pr": "bf:note"
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Funding Information Note",
+          "pr": "bf:noteType"
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Mode of access: Internet from the NREL web site. Address as of 5/8/06: http://www.nrel.gov/docs/fy05osti/37439.pdf; current access available via PURL.",
+          "pr": "rdfs:label"
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type"
+        }
+      ],
+      "id": "b16369525#1.0003",
+      "la": null,
+      "li": null,
+      "pr": "bf:note"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Conference paper ; NREL/CP-520-37439",
+      "pr": "bf:seriesStatement"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "2005",
+      "pr": "dbo:dateStart"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "2005",
+      "pr": "dbo:startDate"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Wang, Qi.",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "National Renewable Energy Laboratory (U.S.)",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Wang, Q.",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Page, M.",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Yan, Y.",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Wang, T.",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "2005",
+      "pr": "dc:date"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Solar cells -- Materials.",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Chemical vapor deposition.",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "36 MATERIALS SCIENCE",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "14 SOLAR ENERGY",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "CARRIER LIFETIME",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "CHEMICAL VAPOR DEPOSITION",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "DECAY",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "EFFICIENCY",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "HETEROJUNCTIONS",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "MIXTURES",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "OPTIMIZATION",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "PASSIVATION",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "RADICALS",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "SILICON",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "SILICON SOLAR CELLS",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "SOLAR CELLS",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "SURFACE TREATMENTS",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "THICKNESS",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "TRANSMISSION ELECTRON MICROSCOPY",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "High throughput approaches to optimization of crystal silicon surface passivation and heterojunction solar cells",
+      "pr": "dcterms:alternative"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "2005",
+      "pr": "dcterms:created"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": "Summary, Etc.",
+      "li": "We use a high-throughput (combinatorial) hot-wire chemical vapor deposition system to passivate the crystal silicon surface and to grow heterojunction silicon solar cells. We study the effectiveness of crystal surface treatments by atomic H or/and NHx radicals, followed by the growth of thin hydrogenated amorphous silicon (a Si:H) films. Treatment and layer properties such as times, thicknesses, and gas mixtures can be continuously graded, creating a two-dimensional sample with each variable varying in one direction. This results in high-throughput optimization of the processes. Effective carrier lifetime is measured by photoconductive decay to evaluate the effectiveness of the surface passivation by surface treatments. The effective carrier lifetime increases from about 5 [micro]s without passivation to about 24 [micro]s with an optimized surface treatment and thickness a-Si:H on single-sided c-Si. Transmission electron microscopy reveals that a-Si:H, a mixed phase, or epitaxial growth of thin-film Si depending on the surface treatment. Improvement in effective carrier lifetime correlates with an immediate a-Si:H growth on c-Si, rather than a mixed phase and epitaxial Si growth. We have obtained an efficiency of 13.4% on a non-textured single-sided heterojunction solar cell on p-type CZ-Si processed with optimized surface treatment.",
+      "pr": "dcterms:description"
+    },
+    {
+      "bn": null,
+      "id": "urn:bnum:16369525",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "urn:lccCoarse:E907-909",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "lang:eng",
+      "la": "English",
+      "li": null,
+      "pr": "dcterms:language"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "High-throughput approaches to optimization of crystal silicon surface passivation and heterojunction solar cells [electronic resource]",
+      "pr": "dcterms:title"
+    },
+    {
+      "bn": null,
+      "id": "resourcetypes:txt",
+      "la": "Text",
+      "li": null,
+      "pr": "dcterms:type"
+    },
+    {
+      "bn": null,
+      "id": "loc:ia",
+      "la": "Electronic Material for Adults",
+      "li": null,
+      "pr": "nypl:catalogBibLocation"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "4 p. : digital, PDF file.",
+      "pr": "nypl:extent"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Golden, Colo. :",
+      "pr": "nypl:placeOfPublication"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Golden, Colo. : National Renewable Energy Laboratory, [2005]",
+      "pr": "nypl:publicationStatement"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "National Renewable Energy Laboratory,",
+      "pr": "nypl:role-publisher"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "GPO Internet E 9.17:NREL/CP-520-37439",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "High-throughput approaches to optimization of crystal silicon surface passivation and heterojunction solar cells [electronic resource] / Q. Wang ... [et al.].",
+      "pr": "nypl:titleDisplay"
+    },
+    {
+      "bn": null,
+      "id": "nypl:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    }
+  ],
+  "item_statements": [
+    {
+      "s": "i16369525-e",
+      "bn": null,
+      "id": null,
+      "la": "application/pdf",
+      "li": "http://www.osti.gov/servlets/purl/15016491-ZrQ6NY/native/",
+      "pr": "bf:electronicLocator"
+    },
+    {
+      "s": "i16369525-e",
+      "bn": null,
+      "id": "urn:bnum:b16369525",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i16369525-e",
+      "bn": null,
+      "id": null,
+      "la": "application/pdf",
+      "li": "http://www.osti.gov/servlets/purl/15016491-ZrQ6NY/native/",
+      "pr": "nypl:electronicLocator"
+    },
+    {
+      "s": "i16369525-e",
+      "bn": null,
+      "id": "urn:itemtype:research",
+      "la": null,
+      "li": null,
+      "pr": "nypl:itemType"
+    },
+    {
+      "s": "i16369525-e",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i16369525-e",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    }
+  ]
+}

--- a/test/data/cb6240214.json
+++ b/test/data/cb6240214.json
@@ -1,0 +1,312 @@
+{
+  "subject_id": "cb6240214",
+  "bib_statements": [
+    {
+      "bn": null,
+      "id": "carriertypes:nc",
+      "la": "volume",
+      "li": null,
+      "pr": "bf:carrier"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "24 cm.",
+      "pr": "bf:dimensions"
+    },
+    {
+      "bn": null,
+      "id": "urn:biblevel:m",
+      "la": "monograph/item",
+      "li": null,
+      "pr": "bf:issuance"
+    },
+    {
+      "bn": null,
+      "id": "mediatypes:n",
+      "la": "unmediated",
+      "li": null,
+      "pr": "bf:media"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "2007",
+      "pr": "dbo:startDate"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "880-07 Zhongguo ren min jie fang jun jun shi ke xue yuan. Zhan zheng li lun he zhan lüe yan jiu bu.",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "880-08 Zhongguo Sunzi bing fa yan jiu hui.",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "880-01 International Symposium on Sun Tzu's Art of War (7th : 2006 : Hangzhou, China)",
+      "pr": "dc:creator"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "2007",
+      "pr": "dc:date"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sunzi, -- active 6th century B.C. -- Congresses.",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": "Varying Form of Title",
+      "li": "Sun tzu's art of war and modern strategy",
+      "pr": "dcterms:alternative"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": "Varying Form of Title",
+      "li": "Di qi jie Sunzi bing fa guo ji yan tao hui lun wen ji",
+      "pr": "dcterms:alternative"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "2007",
+      "pr": "dcterms:created"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": "Summary, Etc.",
+      "li": "这次孙子兵法国际研讨会首次将孙子思想与大国关系和中国和平发展主题相结合,在三天时间里,30多个国家和海峡两岸,香港地区的近300名专家学者,将围绕\"大国关系与国家安全\",\"大国的国防政策\",\"军事互信和军事合作\",\"台海形势及其走向\",\"孙子兵法与世界军事文化遗产\"等…",
+      "pr": "dcterms:description"
+    },
+    {
+      "bn": null,
+      "id": "urn:bnum:6240214",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "urn:isbn:9787802370715",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "urn:isbn:780237071X",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "urn:lccn:  2008402889",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "lang:chi",
+      "la": "Chinese",
+      "li": null,
+      "pr": "dcterms:language"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "880-02 Sunzi bing fa yu xian dai zhan lüe : di qi jie Sunzi bing fa guo ji yan tao hui lun wen ji = Sun tzu's art of war and modern strategy : theses colletion of the 7th international symposium on Sun tzu's art of war / jun shi ke xue yuan zhan zheng li lun he zhan lüe yan jiu bu, Zhongguo Sunzi bing fa yan jiu hui bian.",
+      "pr": "dcterms:title"
+    },
+    {
+      "bn": null,
+      "id": "resourcetypes:txt",
+      "la": "Text",
+      "li": null,
+      "pr": "dcterms:type"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "7, 739 p. : col. ill. ;",
+      "pr": "nypl:extent"
+    },
+    {
+      "bn": null,
+      "id": "genre:b",
+      "la": "Bibliographies",
+      "li": null,
+      "pr": "nypl:genre"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "U101.S96 S7922 2006",
+      "pr": "nypl:lccClassification"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Beijing Shi :",
+      "pr": "nypl:placeOfPublication"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Jun shi ke xue chu ban she,",
+      "pr": "nypl:role-publisher"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Sunzi bing fa yu xian dai zhan lüe : di qi jie Sunzi bing fa guo ji yan tao hui lun wen ji = Sun tzu's art of war and modern strategy : theses colletion of the 7th international symposium on Sun tzu's art of war / jun shi ke xue yuan zhan zheng li lun he zhan lüe yan jiu bu, Zhongguo Sunzi bing fa yan jiu hui bian.",
+      "pr": "nypl:titleDisplay"
+    },
+    {
+      "bn": null,
+      "id": "nypl:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    },
+    {
+      "bn": null,
+      "id": "nypl:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": "Bibliography, Etc. Note",
+      "li": "Includes bibliographical references.",
+      "pr": "skos:note"
+    }
+  ],
+  "item_statements": [
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": "urn:barcode:CU13833405",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": "accessMessage:1",
+      "la": "Use in library",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": "urn:bnum:cb6240214",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": "catalogItemType:1",
+      "la": "non-circ",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": "orgs:0002",
+      "la": "Columbia University Libraries",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "U101.S96 S7922 2006",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    },
+    {
+      "s": "ci7423916",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    }
+  ]
+}


### PR DESCRIPTION
*This is blocked by an update to nypl-core-objects https://github.com/NYPL/nypl-core-objects/pull/20*

Adds an additional clause to the the Bib.isResearch model method that
allows a bib to evaluate as research if 1) its items consist entirely of
electronic resources, and 2) its location (nypl:catalogBibLocation) maps
to a nypl-core location with collectionType "Research"

https://jira.nypl.org/browse/SCC-283

Also adds documentation about updating fixtures to README