### PR TITLE
Add fix for failure to surface item object_type

### DIFF
--- a/lib/models/item.js
+++ b/lib/models/item.js
@@ -43,7 +43,7 @@ Item.byId = (id) => {
 }
 
 Item.fromStatements = (stmts) => {
-  var doc = new Item(stmts.map((s) => ({ subject_id: s.s, predicate: s.pr, object_id: s.id, object_literal: s.li, object_label: s.la })))
+  var doc = new Item(stmts.map((s) => ({ subject_id: s.s, predicate: s.pr, object_id: s.id, object_literal: s.li, object_label: s.la, object_type: s.ty })))
   doc.uri = stmts[0].s
   return doc
 }

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -58,4 +58,30 @@ describe('Item model', function () {
       })
     })
   })
+
+  describe('identifier representations in store', function () {
+    it('should pass (older) urn prefixed identifier values through without modification', function () {
+      return Bib.byId('b17655587').then((bib) => {
+        // Check a specific known item:
+        let item = bib.items().filter((i) => i.id === 'i17906175').pop()
+
+        // Check the only dcterms:identifier statement:
+        expect(item.statement('dcterms:identifier')).to.be.a('object')
+        expect(item.statement('dcterms:identifier')).to.have.property('object_id', 'urn:barcode:33333205133792')
+        expect(item.statement('dcterms:identifier')).to.have.property('object_type', undefined)
+      })
+    })
+
+    it('should pass (newer) non-urn-prefixed values through with object_type when avaiable', function () {
+      return Bib.byId('b10781594').then((bib) => {
+        // Check the only item:
+        let firstItem = bib.items().pop()
+
+        // Check the only dcterms:identifier statement:
+        expect(firstItem.statement('dcterms:identifier')).to.be.a('object')
+        expect(firstItem.statement('dcterms:identifier')).to.have.property('object_id', '33433057085312')
+        expect(firstItem.statement('dcterms:identifier')).to.have.property('object_type', 'bf:Barcode')
+      })
+    })
+  })
 })


### PR DESCRIPTION
Fixes a bug where `object_type` isn't populated in Item instances, which
prevents downstream components from acting on a statement's object_type
(e.g. dcterms:identifier "33433047560440" is meaningless without knowing
its object_type is 'bf:Barcode'). This fix addresses an active bug where
item barcode identifiers aren't indexed with with their type.