### PR TITLE
SCC-2207 Add holding class for retrieval

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -31,8 +31,14 @@ function bibsStream (options) {
 function bibs (bnums) {
   var query = _bibSqlQueryString({ subject_ids: bnums, offset: 0, limit: bnums.length })
   return db.many(query.sql, query.values, query.options).then((resources) => {
-    if (resources) logger.debug('DB: Retrieved ' + resources.length + ' resources for ' + bnums.length + ' bnums')
-    else logger.debug('DB: Retrieved NO bibs for ' + bnums)
+    if (resources) {
+      logger.debug('DB: Retrieved ' + resources.length + ' resources for ' + bnums.length + ' bnums')
+
+      // Separate item and holding statements for all fetched resources
+      resources = resources.map((resource) => _separateItemAndHoldingRecords(resource))
+    } else {
+      logger.debug('DB: Retrieved NO bibs for ' + bnums)
+    }
 
     return resources
   })
@@ -46,11 +52,32 @@ function bib (id) {
   logger.debug('DB: db.one(' + query.sql + ')')
   return db.one(query.sql, query.values, query.options).then((resource) => {
     logger.debug('DB: Got rec: ', resource)
-    if (resource && resource.bib_statements) logger.debug('DB: Retrieved ' + resource.bib_statements.length + ' bib statements, ' + (resource.item_statements && resource.item_statements.length ? resource.item_statements.length + ' item statements' : ''))
-    else logger.debug('DB: Retrieved null bib for ' + id)
+    if (resource && resource.bib_statements) {
+      logger.debug('DB: Retrieved ' + resource.bib_statements.length + ' bib statements, ' + (resource.item_statements && resource.item_statements.length ? resource.item_statements.length + ' item statements' : ''))
+
+      // Separate item from holding statements
+      if (resource.item_statements && resource.item_statements.length) resource = _separateItemAndHoldingRecords(resource)
+    } else {
+      logger.debug('DB: Retrieved null bib for ' + id)
+    }
 
     return resource
   })
+}
+
+/**
+ * This function parses out item and holding statements from the response object, as they are not distinguished
+ * in the SQL query. It relies on the id prefixes for each type to separate the statements into different arrays.
+ *
+ * @param {object} resource An object containing triple statements for the bib record, with associated item and holding statements
+ */
+function _separateItemAndHoldingRecords (resource) {
+  if (resource.item_statements && resource.item_statements.length) {
+    resource.item_statements = resource.item_statements.filter((s) => s.s[0] === 'i')
+    resource.holding_statements = resource.item_statements.filter((s) => s.s[0] === 'h')
+  }
+
+  return resource
 }
 
 /**
@@ -133,7 +160,8 @@ function _bibSqlQueryString (options) {
         ) _BS
     ) as bib_statements,
     (
-      SELECT ${_jsonAggSelectString('_IS', { additionalColumns: { s: 'subject_id', bn: 'blanknode' } })} AS statements
+      SELECT 
+        ${_jsonAggSelectString('_IS', { additionalColumns: { s: 'subject_id', bn: 'blanknode' } })} FILTER (WHERE AS statements
       FROM (
         SELECT __IS.subject_id, __IS.predicate, __IS.object_id, __IS.object_type, __IS.object_literal, __IS.object_label,
         (

--- a/lib/db.js
+++ b/lib/db.js
@@ -161,7 +161,7 @@ function _bibSqlQueryString (options) {
     ) as bib_statements,
     (
       SELECT 
-        ${_jsonAggSelectString('_IS', { additionalColumns: { s: 'subject_id', bn: 'blanknode' } })} FILTER (WHERE AS statements
+        ${_jsonAggSelectString('_IS', { additionalColumns: { s: 'subject_id', bn: 'blanknode' } })} AS statements
       FROM (
         SELECT __IS.subject_id, __IS.predicate, __IS.object_id, __IS.object_type, __IS.object_literal, __IS.object_label,
         (

--- a/lib/db.js
+++ b/lib/db.js
@@ -73,8 +73,8 @@ function bib (id) {
  */
 function _separateItemAndHoldingRecords (resource) {
   if (resource.item_statements && resource.item_statements.length) {
-    resource.item_statements = resource.item_statements.filter((s) => s.s[0] === 'i')
     resource.holding_statements = resource.item_statements.filter((s) => s.s[0] === 'h')
+    resource.item_statements = resource.item_statements.filter((s) => s.s[0] === 'i')
   }
 
   return resource

--- a/lib/models/bib.js
+++ b/lib/models/bib.js
@@ -2,6 +2,7 @@
 
 const Base = require('./base')
 const Item = require('./item')
+const Holding = require('./holding')
 const db = require('../db')
 const utils = require('../utils')
 const sierraLocationMapping = require('@nypl/nypl-core-objects')('by-sierra-location')
@@ -31,8 +32,12 @@ class Bib extends Base {
       (nonElectronicItemsCount === 0 && this.researchLocations().length > 0)
   }
 
-  items () {
+  items() {
     return this._items || []
+  }
+
+  holdings() {
+    return this._holdings || []
   }
 
   /**
@@ -64,6 +69,13 @@ Bib.fromDbJsonResult = (result) => {
     doc._items = utils.groupBy(result.item_statements, 's')
     doc._items = doc._items.map(Item.fromStatements)
   }
+
+  doc._holdings = []
+  if (result.holding_statements) {
+    doc._holdings = utils.groupBy(result.holding_statements, 's')
+    doc._holdings = doc._holdings.map(Holding.fromStatements)
+  }
+
   return doc
 }
 

--- a/lib/models/bib.js
+++ b/lib/models/bib.js
@@ -32,11 +32,11 @@ class Bib extends Base {
       (nonElectronicItemsCount === 0 && this.researchLocations().length > 0)
   }
 
-  items() {
+  items () {
     return this._items || []
   }
 
-  holdings() {
+  holdings () {
     return this._holdings || []
   }
 

--- a/lib/models/bib.js
+++ b/lib/models/bib.js
@@ -2,6 +2,7 @@
 
 const Base = require('./base')
 const Item = require('./item')
+const Holding = require('./holding')
 const db = require('../db')
 const utils = require('../utils')
 const sierraLocationMapping = require('@nypl/nypl-core-objects')('by-sierra-location')
@@ -64,6 +65,13 @@ Bib.fromDbJsonResult = (result) => {
     doc._items = utils.groupBy(result.item_statements, 's')
     doc._items = doc._items.map(Item.fromStatements)
   }
+
+  doc._holdings = []
+  if (result.holding_statements) {
+    doc._holdings = utils.groupBy(result.holding_statements, 's')
+    doc._holdings = doc._holdings.map(Holding.fromStatements)
+  }
+
   return doc
 }
 

--- a/lib/models/holding.js
+++ b/lib/models/holding.js
@@ -1,0 +1,19 @@
+const Base = require('./base')
+const db = require('../db')
+
+// Holding records have no special methods at the moment
+// so this can directly subclass Base with no additional methods. Obviously it
+// can be extended in the future
+class Holding extends Base {}
+
+Holding.byId = (id) => {
+  return db.getStatements('resource', id).then((s) => new Holding(s))
+}
+
+Holding.fromStatements = (stmts) => {
+  var doc = new Holding(stmts.map((s) => ({ subject_id: s.s, predicate: s.pr, object_id: s.id, object_literal: s.li, object_label: s.la, object_type: s.ty })))
+  doc.uri = stmts[0].s
+  return doc
+}
+
+module.exports = Holding

--- a/lib/models/holding.js
+++ b/lib/models/holding.js
@@ -11,7 +11,24 @@ Holding.byId = (id) => {
 }
 
 Holding.fromStatements = (stmts) => {
-  var doc = new Holding(stmts.map((s) => ({ subject_id: s.s, predicate: s.pr, object_id: s.id, object_literal: s.li, object_label: s.la, object_type: s.ty })))
+  var doc = new Holding(stmts.map((s) => {
+    const stmt = {
+      subject_id: s.s,
+      predicate: s.pr,
+      object_id: s.id,
+      object_literal: s.li,
+      object_label: s.la,
+      object_type: s.ty
+    }
+
+    if (s.bn) {
+      const bnStmt = s.bn.map(Base.parseStatementFromJsonDbResult)
+      stmt.blanknode = new Base(bnStmt)
+    }
+
+    return stmt
+  }))
+
   doc.uri = stmts[0].s
   return doc
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery-store-models",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A collection of model classes for interacting with NYPL Discovery Store",
   "main": "index.js",
   "scripts": {

--- a/test/data/b11254422.json
+++ b/test/data/b11254422.json
@@ -1,0 +1,1042 @@
+{
+    "subject_id": "b11254422",
+    "bib_statements": [
+      {
+        "bn": null,
+        "id": "carriertypes:nc",
+        "la": "volume",
+        "li": null,
+        "pr": "bf:carrier",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "30 cm.",
+        "pr": "bf:dimensions",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "urn:biblevel:s",
+        "la": "serial",
+        "li": null,
+        "pr": "bf:issuance",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "mediatypes:n",
+        "la": "unmediated",
+        "li": null,
+        "pr": "bf:media",
+        "ty": null
+      },
+      {
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": "Note",
+            "pr": "bf:noteType",
+            "ty": null
+          },
+          {
+            "id": "bf:Note",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Cover title.",
+            "pr": "rdfs:label",
+            "ty": null
+          }
+        ],
+        "id": "b11254422#1.0000",
+        "la": null,
+        "li": null,
+        "pr": "bf:note",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "9999",
+        "pr": "dbo:endDate",
+        "ty": "xsd:integer"
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "1981",
+        "pr": "dbo:startDate",
+        "ty": "xsd:integer"
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "1981",
+        "pr": "dc:date",
+        "ty": "xsd:integer"
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Photography -- History -- Periodicals.",
+        "pr": "dc:subject",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Photography, Artistic -- Periodicals.",
+        "pr": "dc:subject",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Fotogeschichte",
+        "pr": "dcterms:alternative",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Fotogeschichte",
+        "pr": "dcterms:alternative",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "1981",
+        "pr": "dcterms:created",
+        "ty": "xsd:integer"
+      },
+      {
+        "bn": null,
+        "id": "11254422",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:identifier",
+        "ty": "nypl:Bnumber"
+      },
+      {
+        "bn": null,
+        "id": "0720-5260",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:identifier",
+        "ty": "bf:Issn"
+      },
+      {
+        "bn": null,
+        "id": "82645711",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:identifier",
+        "ty": "bf:Lccn"
+      },
+      {
+        "bn": null,
+        "id": "(WaOLN)nyp1262092",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:identifier",
+        "ty": "bf:Identifier"
+      },
+      {
+        "bn": null,
+        "id": "lang:ger",
+        "la": "German",
+        "li": null,
+        "pr": "dcterms:language",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Fotogeschichte.",
+        "pr": "dcterms:title",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "resourcetypes:txt",
+        "la": "Text",
+        "li": null,
+        "pr": "dcterms:type",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "loc:mal",
+        "la": "Schwarzman Building - Main Reading Room 315",
+        "li": null,
+        "pr": "nypl:catalogBibLocation",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "loc:mas",
+        "la": "Schwarzman Building - Photography Collection Room 308",
+        "li": null,
+        "pr": "nypl:catalogBibLocation",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "v. : ill. ;",
+        "pr": "nypl:extent",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "TR15 .F67",
+        "pr": "nypl:lccClassification",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Frankfurt am Main :",
+        "pr": "nypl:placeOfPublication",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Frankfurt am Main : T. Starl, 1981-",
+        "pr": "nypl:publicationStatement",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "T. Starl,",
+        "pr": "nypl:role-publisher",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Jahrg. 1, Heft 1-",
+        "pr": "nypl:serialPublicationDates",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "MFWA+ 89-1277",
+        "pr": "nypl:shelfMark",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "false",
+        "pr": "nypl:suppressed",
+        "ty": "xsd:boolean"
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Fotogeschichte.",
+        "pr": "nypl:titleDisplay",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "nypl:Collection",
+        "la": null,
+        "li": null,
+        "pr": "rdfs:type",
+        "ty": null
+      }
+    ],
+    "item_statements": [],
+    "holding_statements": [
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "MFWA+ 89-1277",
+        "pr": "bf:physicalLocation",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "27(1988)-40:156(2020)-",
+        "pr": "dcterms:coverage",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "no. 3840 (2018/2020)",
+        "pr": "dcterms:coverage",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "{\"PRINT\"}",
+        "pr": "dcterms:format",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "15",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Expected",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "40:157 (2020--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0000",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "14",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "40:156 (2020--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0001",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "9",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "39:151 (2019--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0002",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "13",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "40:155 (2020--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0003",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "12",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "39:154 (2019--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0004",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "11",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "39:153 (2019--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0005",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "10",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "39:152 (2019--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0006",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "7",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "38:149 (2018--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0007",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "6",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "38:148 (2018--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0008",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "5",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "38:147 (2018--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0009",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "4",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "37:146 (2017--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0010",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "3",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "37:145 (2017--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0011",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "2",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "37:144 (2017--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0012",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "1",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "37:143 (2017--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0013",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "8",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "38:150 (2018--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0014",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": "urn:bnum:b11254422",
+        "la": null,
+        "li": null,
+        "pr": "nypl:bnum",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": "loc:rc2ma",
+        "la": "Offsite",
+        "li": null,
+        "pr": "nypl:holdingLocation",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "MFWA+ 89-1277",
+        "pr": "nypl:shelfMark",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "false",
+        "pr": "nypl:suppressed",
+        "ty": "xsd:boolean"
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": "nypl:Holding",
+        "la": null,
+        "li": null,
+        "pr": "rdfs:type",
+        "ty": null
+      }
+    ]
+  }

--- a/test/holding-test.js
+++ b/test/holding-test.js
@@ -1,0 +1,68 @@
+const { expect } = require('chai')
+const fixtures = require('./fixtures')
+const Bib = require('../index').Bib
+
+describe('Holding Model', () => {
+  before(fixtures.enable)
+
+  after(fixtures.disable)
+
+  it('should set core fields', () => {
+    return Bib.byId('b11254422').then((bib) => {
+      expect(bib.holdings()).to.be.a('array')
+      expect(bib.holdings()).to.have.lengthOf(1)
+
+      const holding = bib.holdings()[0]
+
+      expect(holding).to.be.a('object')
+      expect(holding).to.have.property('id', 'h1000993')
+
+      expect(holding.literal('nypl:suppressed')).to.equal('false')
+
+      expect(holding.literal('nypl:shelfMark')).to.equal('MFWA+ 89-1277')
+
+      expect(holding.objectId('rdfs:type')).to.equal('nypl:Holding')
+    })
+  })
+
+  it('should get an array of holding statements', () => {
+    return Bib.byId('b11254422').then((bib) => {
+      const holding = bib.holdings()[0]
+
+      expect(holding.literals('dcterms:coverage')).to.have.lengthOf(2)
+      expect(holding.literals('dcterms:coverage')[0]).to.equal('27(1988)-40:156(2020)-')
+      expect(holding.literals('dcterms:coverage')[1]).to.equal('no. 3840 (2018/2020)')
+    })
+  })
+
+  it('should contain a location code and label', () => {
+    return Bib.byId('b11254422').then((bib) => {
+      const holding = bib.holdings()[0]
+
+      expect(holding.objectId('nypl:holdingLocation')).to.equal('loc:rc2ma')
+      expect(holding.statement('nypl:holdingLocation').object_label).to.equal('Offsite')
+    })
+  })
+
+  it('should contain an array of check in cards as blanknodes', () => {
+    return Bib.byId('b11254422').then((bib) => {
+      const holding = bib.holdings()[0]
+
+      expect(holding.blankNodes('dcterms:hasPart')).to.have.lengthOf(15)
+
+      const firstBlankNode = holding.blankNodes('dcterms:hasPart')[1]
+      expect(firstBlankNode.objectId('rdf:type')).to.equal('nypl:CheckInBox')
+      expect(firstBlankNode.literal('dcterms:coverage')).to.equal('40:156 (2020--)')
+      expect(firstBlankNode.literal('bf:status')).to.equal('Arrived')
+      expect(firstBlankNode.literal('bf:count')).to.equal(null)
+      expect(firstBlankNode.literal('bf:part')).to.equal('14')
+
+      const secondBlankNode = holding.blankNodes('dcterms:hasPart')[9]
+      expect(secondBlankNode.objectId('rdf:type')).to.equal('nypl:CheckInBox')
+      expect(secondBlankNode.literal('dcterms:coverage')).to.equal('38:147 (2018--)')
+      expect(secondBlankNode.literal('bf:status')).to.equal('Arrived')
+      expect(secondBlankNode.literal('bf:count')).to.equal(null)
+      expect(secondBlankNode.literal('bf:part')).to.equal('5')
+    })
+  })
+})


### PR DESCRIPTION
To integrate Holdings data into the discovery API, we need to fetch the statements for the holdings separate from the item statements.

The query SQL query fetches simply an array of statements associated with a bib (or multiple bibs) record at uses this to construct the item objects. I think it would be possible to modify that query (possibly with a `FILTER` in the `item_statement` aggregation), but I think that might be difficult to maintain and understand in the future. This simply checks the identifier prefix for each statement returned in the `item_statements` array and sorts them on if it is an `i` or `h`. This is a simple approach that I don't think poses any performance issues since it is such a simple check.

Some questions I have on this approach:

- Should we rename the `item_statement` in the query? I've left it as is for now since I couldn't think of anything better
- Is there any potential for side effects here? I've tested the code and I believe it will just pass through item statements if no holding statements are present.
- Philosophically, is this better to be done in the query? I could see an argument for that, but I actually worry it would have a greater performance impact since it would involve adding another subquery, though in likelihood, that would have less of an impact that running `filter` on the existing array.