### PR TITLE
Remove statement sorting (i.e. don't override sort)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo centralizes access to the discovery-store, a Postgres database organiz
 
 ### Current Version
 
-v1.4.1
+v1.4.2
 
 # Usage
 

--- a/lib/models/base.js
+++ b/lib/models/base.js
@@ -8,10 +8,6 @@ class Base {
 
   each (pred, cb) {
     return this.statements(pred)
-      .sort((p1, p2) => {
-        if (p1.object_id && p2.object_id) return p1.object_id > p2.object_id ? 1 : -1
-        else if (p1.object_literal && p2.object_literal) return p1.object_literal > p2.object_literal ? 1 : -1
-      })
       .map((trip) => cb(trip))
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery-store-models",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A collection of model classes for interacting with NYPL Discovery Store",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Seems there was code to sort statements for a given predicate by
object_id or literal length. This was probably done partially to coerce
a somewhat consistent sort (of object_ids) and improve display (shorter
titles should probably be shown before longer titles?) In any case, it
was overriding the default sort the statements had when extracted in
some cases, which is throwing off parallel field relationships. So let's
not set a custom sort and just accept the original order of statements.

This is v1.4.2