### PR TITLE
Noref fix pg dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo centralizes access to the discovery-store, a Postgres database organiz
 
 ### Current Version
 
-v1.4.1
+v1.4.2
 
 # Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery-store-models",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2243,9 +2243,9 @@
       }
     },
     "pg-query-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-1.1.1.tgz",
-      "integrity": "sha1-Zel0Nu+AnR4WDrqE6/EbnkdC6rQ=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-1.1.2.tgz",
+      "integrity": "sha512-84hsUVjbrvXYIpVH+6FrKajfOnmTo7Wc/CXPtSyv41JmUnLcQ2lcVrkR7+m4VPtL28FdcZA7Q7ab4X0za4BhrQ==",
       "dev": true,
       "requires": {
         "pg-cursor": "1.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@nypl/nypl-core-objects": "^2.0.0",
+        "pg-int8": "^1.0.1",
         "pg-promise": "^7.4.0",
         "winston": "^2.4.0"
       },
@@ -2800,6 +2801,14 @@
       "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-1.3.0.tgz",
       "integrity": "sha1-siDxkIl2t7QNqjc8etpfyoI6sNk=",
       "dev": true
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/pg-minify": {
       "version": "0.5.4",
@@ -6177,6 +6186,11 @@
       "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-1.3.0.tgz",
       "integrity": "sha1-siDxkIl2t7QNqjc8etpfyoI6sNk=",
       "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-minify": {
       "version": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/NYPL-discovery/discovery-store-models#readme",
   "dependencies": {
     "@nypl/nypl-core-objects": "^2.0.0",
+    "pg-int8": "^1.0.1",
     "pg-promise": "^7.4.0",
     "winston": "^2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discovery-store-models",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A collection of model classes for interacting with NYPL Discovery Store",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "dotenv": "^5.0.0",
     "minimist": "^1.2.5",
     "mocha": "^8.3.2",
-    "pg-query-stream": "^1.1.1",
+    "pg-query-stream": "^1.1.2",
     "sinon": "^4.2.0",
     "standard": "^10.0.3"
   },


### PR DESCRIPTION
Fix strange issue with `pg-int8` dependency. It appears to be a deep dependency of `pg-query-stream`, but is not automatically installed, so adding it explicitly. Also updating `pg-query-stream` to latest patch version.

This is `v1.4.3`